### PR TITLE
Make timeout and port configurable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "tsserver-debug",
+	"name": "vscode-tsserver-debug",
 	"version": "0.0.1",
 	"lockfileVersion": 1,
 	"requires": true,

--- a/package.json
+++ b/package.json
@@ -24,10 +24,26 @@
 	],
 	"main": "./out/extension.js",
 	"contributes": {
+		"configuration": {
+			"title": "TS Server Debug",
+			"properties": {
+				"tsserver-debug.discoveryTimeout": {
+					"type": "integer",
+					"default": 3000,
+					"description": "The number of milliseconds to wait to discover an port that can be used for remote debugging."
+				},
+				"tsserver-debug.debugPort": {
+					"type": "integer",
+					"default": 9559,
+					"description": "The default debug port to use."
+				}
+			}
+		},
 		"commands": [
 			{
 				"command": "io.wheream.vscode-tsserver-debug.restart-with-debugging",
-         "title": "Restart TS Server with debugging enabled"
+				"title": "Restart TS server with debugging enabled",
+				"category": "TypeScript"
 			}
 		],
 		"menus": {


### PR DESCRIPTION
- Makes the timeout and default port number configurable via workspace/user settings
- Changes the default timeout to 3 seconds (lowest second-resolution timeout that seemed to work on my Windows system).
- Adds an error message when port discovery fails.
